### PR TITLE
Refactor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,15 @@ version = "0.4.0"
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
-HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Molecules = "5de6a177-b489-40a9-b2f4-524242b9b679"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 libcint_jll = "574b78ca-bebd-517c-801d-4735c93a9686"
+
+[extras]
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Combinatorics = "1"
@@ -23,3 +25,6 @@ StaticArrays = "1.4"
 Molecules = "0.3"
 julia = "^1.6"
 libcint_jll = "5"
+
+[targets]
+test = ["HDF5", "Test"]

--- a/src/Integrals/Multipole.jl
+++ b/src/Integrals/Multipole.jl
@@ -1,40 +1,3 @@
-function gen_multipole(BS::BasisSet, callback, rank::Integer)
-    out = zeros(BS.nbas, BS.nbas, Iterators.repeated(3, rank)...)
-
-    Nvals = num_basis.(BS.basis)
-    Nmax = maximum(Nvals)
-
-    # Offset list for each shell, used to map shell index to AO index
-    ao_offset = [sum(Nvals[1:(i-1)]) for i = 1:BS.nshells]
-
-    buf_arrays = [zeros(Cdouble, 3^rank * Nmax^2) for _ = 1:Threads.nthreads()]
-
-    Threads.@threads :static for i in 1:BS.nshells
-        Ni = Nvals[i]
-        buf = buf_arrays[Threads.threadid()]
-        ioff = ao_offset[i]
-        for j in i:BS.nshells
-            Nj = Nvals[j]
-            Nij = Ni*Nj
-            joff = ao_offset[j]
-
-            callback(buf, BS, i, j)
-            I = (ioff+1):(ioff+Ni)
-            J = (joff+1):(joff+Nj)
-
-            # Get strides for each cartesian product
-            for (n, ks) in enumerate(Iterators.product(Iterators.repeated(1:3, rank)...))
-                r = Nij*(n-1)+1:n*Nij
-                kvals = reshape(view(buf, r), Ni, Nj)
-                out[I,J,ks...] .+= kvals
-                if i != j
-                    out[J,I,ks...] .+= kvals'
-                end
-            end
-        end
-    end
-    return out
-end
 
 dipole!(out, BS::BasisSet{LCint}, i, j) = cint1e_r_sph!(out, [i,j], BS.lib)
 quadrupole!(out, BS::BasisSet{LCint}, i, j) = cint1e_rr_sph!(out, [i,j], BS.lib)
@@ -62,7 +25,7 @@ function hexadecapole(BS::BasisSet, i, j)
     return out
 end
 
-dipole(BS::BasisSet) = gen_multipole(BS, dipole!, 1)
-quadrupole(BS::BasisSet) = gen_multipole(BS, quadrupole!, 2)
-octupole(BS::BasisSet) = gen_multipole(BS, octupole!, 3)
-hexadecapole(BS::BasisSet) = gen_multipole(BS, hexadecapole!, 4)
+dipole(BS::BasisSet) = get_1e_matrix(dipole!, BS, 1)
+quadrupole(BS::BasisSet) = get_1e_matrix(quadrupole!, BS, 2)
+octupole(BS::BasisSet) = get_1e_matrix(octupole!, BS, 3)
+hexadecapole(BS::BasisSet) = get_1e_matrix(hexadecapole!, BS, 4)

--- a/src/Libcint.jl
+++ b/src/Libcint.jl
@@ -130,6 +130,22 @@ function cint1e_ipovlp_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LC
     cint1e_ipovlp_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
+function cint1e_ipipovlp_sph!(buf, shls, atm, natm, bas, nbas, env)
+    @ccall LIBCINT.cint1e_ipipovlp_sph(
+                                    buf  :: Ptr{Cdouble},
+                                    shls :: Ptr{Cint},
+                                    atm  :: Ptr{Cint},
+                                    natm :: Cint,
+                                    bas  :: Ptr{Cint},
+                                    nbas :: Cint,
+                                    env  :: Ptr{Cdouble}
+                                   )::Cvoid
+end
+function cint1e_ipipovlp_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint)
+    cint1e_ipipovlp_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
+end
+
+
 function cint1e_ipkin_sph!(buf, shls, atm, natm, bas, nbas, env)
     @ccall LIBCINT.cint1e_ipkin_sph(
                                     buf  :: Ptr{Cdouble},

--- a/src/Libcint.jl
+++ b/src/Libcint.jl
@@ -9,7 +9,7 @@ module Libcint
 using GaussianBasis: BasisSet, LCint
 
 export cint1e_kin_sph!, cint1e_nuc_sph!, cint1e_ovlp_sph!, cint2c2e_sph!, cint2e_sph!, cint3c2e_sph!
-export cint1e_ipkin_sph!, cint1e_ipnuc_sph!, cint1e_ipovlp_sph!, cint2e_ip1_sph!, cint1e_r_sph!
+export cint1e_ipkin_sph!, cint1e_ipnuc_sph!, cint1e_ipovlp_sph!, cint1e_ipipovlp_sph!, cint2e_ip1_sph!, cint1e_r_sph!
 export cint1e_r_sph!, cint1e_rr_sph!, cint1e_rrr_sph!, cint1e_rrrr_sph!
 
 using libcint_jll


### PR DESCRIPTION
This PR is a bit of a mixed bag, apologies.

## Changes
- improved performance of libcint-backend `ERI_2e4c!` by a factor of ~2 by avoiding superfluous allocations on the julia side
- add a binding for `cint1e_ipipovlp_sph!` in libcint
- combine the `gen_multipole` function from the last PR with the already existing `get_1e_matrix`
- Make Test and HDF5 test dependencies

Also, the previous use of thread-local buffers is [vulnerable to race conditions that give wrong results](https://julialang.org/blog/2023/07/PSA-dont-use-threadid/). I replace them by the `@threads :static` pattern whenever I touch one, however, some still remain.