### PR TITLE
Replace `@threads :static` by task based worker pools

### DIFF
--- a/src/Gradients/TwoElectronGrad.jl
+++ b/src/Gradients/TwoElectronGrad.jl
@@ -212,7 +212,7 @@ function ∇sparseERI_2e4c(BS::BasisSet, iA)
         end
     end
 
-    buf_arrays = [zeros(Cdouble, 3*Nmax^4) for _ = 1:Threads.nthreads()]
+    buf = zeros(Cdouble, 3*Nmax^4)
     
     # i,j,k,l => Shell indexes starting at zero
     # I, J, K, L => AO indexes starting at one
@@ -220,7 +220,6 @@ function ∇sparseERI_2e4c(BS::BasisSet, iA)
     #@sync for ij in eachindex(ij_vals)
         #Threads.@spawn begin
         #@inbounds begin
-            buf = buf_arrays[Threads.threadid()]
             i,j = ij_vals[ij]
             Ni, Nj = Nvals[i], Nvals[j]
             Nij = Ni*Nj

--- a/src/Integrals/OneElectron.jl
+++ b/src/Integrals/OneElectron.jl
@@ -1,14 +1,14 @@
 # Backend: Libcint
 function overlap!(out, BS::BasisSet{LCint}, i, j)
-    cint1e_ovlp_sph!(out, [i,j], BS.lib)
+    cint1e_ovlp_sph!(out, @SVector([i,j]), BS.lib)
 end
 
 function kinetic!(out, BS::BasisSet{LCint}, i, j)
-    cint1e_kin_sph!(out, [i,j], BS.lib)
+    cint1e_kin_sph!(out, @SVector([i,j]), BS.lib)
 end
 
 function nuclear!(out, BS::BasisSet{LCint}, i, j)
-    cint1e_nuc_sph!(out, [i,j], BS.lib)
+    cint1e_nuc_sph!(out, @SVector([i,j]), BS.lib)
 end
 
 # Backend: ACSint -- fall back 

--- a/src/Integrals/TwoElectronFourCenter.jl
+++ b/src/Integrals/TwoElectronFourCenter.jl
@@ -1,13 +1,11 @@
 function sparseERI_2e4c(BS::BasisSet, cutoff = 1e-12)
-    T = eltype(BS.atoms[1].xyz)
-
     # Number of unique integral elements
     N = (BS.nbas^2 - BS.nbas) ÷ 2 + BS.nbas
     N = (N^2 - N) ÷ 2 + N
 
     # Pre allocate output
-    out = zeros(T, N)
-    indexes = Array{NTuple{4,Int16}}(undef, N)
+    out = zeros(Cdouble, N)
+    indexes = Vector{NTuple{4,Int16}}(undef, N)
 
     # Pre compute a list of angular momentum numbers (l) for each shell
     Nvals = num_basis.(BS.basis)
@@ -20,90 +18,75 @@ function sparseERI_2e4c(BS::BasisSet, cutoff = 1e-12)
     num_ij = (BS.nshells^2 - BS.nshells) ÷ 2 + BS.nshells
 
     # Pre allocate array to save ij pairs
-    ij_vals = Array{NTuple{2,Int32}}(undef, num_ij)
+    ij_vals = Vector{NTuple{2,Int32}}(undef, num_ij)
 
     # Pre allocate array to save σij, that is the screening parameter for Schwarz 
-    σvals = zeros(T, num_ij)
+    σvals = zeros(Cdouble, num_ij)
 
     ### Loop thorugh i and j such that i ≤ j. Save each pair into ij_vals and compute √σij for integral screening
+    tmp = zeros(Cdouble, Nmax^4)
     lim = Int32(BS.nshells - 1)
-    for i = UnitRange{Int32}(zero(Int32),lim)
-        @inbounds begin
+    @inbounds for i = zero(Int32):lim
         Li2 = Nvals[i+1]^2
-            for j = UnitRange{Int32}(i, lim)
-                Lj2 = Nvals[j+1]^2
-                buf = zeros(T, Li2*Lj2)
-                idx = index2(i,j) + 1
-                ij_vals[idx] = (i+1,j+1)
-                ERI_2e4c!(buf, BS, i+1, i+1, j+1 ,j+1)
-                σvals[idx] = √maximum(buf)
-            end
+        for j = i:lim
+            Lj2 = Nvals[j+1]^2
+            idx = index2(i,j) + 1
+            ij_vals[idx] = (i+1,j+1)
+            ERI_2e4c!(tmp, BS, i+1, i+1, j+1 ,j+1)
+            σvals[idx] = √maximum(tmp)
         end
     end
 
-    buf_arrays = [zeros(T, Nmax^4) for _ = 1:Threads.nthreads()]
-    
+    ijkl_vals = Iterators.flatten((((ij_vals[ij]..., ij_vals[kl]...) for ij in 1:kl if σvals[ij] * σvals[kl] > cutoff) for kl = 1:num_ij))
+
+    allocate(body) = body(zeros(Cdouble, Nmax^4))
     # i,j,k,l => Shell indexes starting at zero
     # I, J, K, L => AO indexes starting at one
-    @sync for ij in eachindex(ij_vals)
-        Threads.@spawn begin
+    workerpool(allocate, ijkl_vals; chunksize=10) do (i,j,k,l), buf
         @inbounds begin
-            buf = buf_arrays[Threads.threadid()]
-            i,j = ij_vals[ij] 
-            Li, Lj = Nvals[i], Nvals[j]
+            Li, Lj, Lk, Ll = map(n->Nvals[n], (i,j,k,l))
             Lij = Li*Lj
-            ioff = ao_offset[i]
-            joff = ao_offset[j]
-            for kl in ij:num_ij
-                σ = σvals[ij]*σvals[kl]
-                if σ < cutoff
-                    continue
-                end
-                k,l = ij_vals[kl] 
-                Lk, Ll = Nvals[k], Nvals[l]
-                Lijk = Lij*Lk
-                koff = ao_offset[k]
-                loff = ao_offset[l]
+            Lijk = Lij*Lk
 
-                # Compute ERI
-                ERI_2e4c!(buf, BS, i, j, k ,l)
+            ioff, joff, koff, loff = map(n->ao_offset[n], (i,j,k,l))
 
-                ### This block aims to retrieve unique elements within buf and map them to AO indexes
-                # is, js, ks, ls are indexes within the shell e.g. for a p shell is = (1, 2, 3)
-                # bl, bkl, bjkl are used to map the (i,j,k,l) index into a one-dimensional index for buf
-                # That is, get the correct integrals for the AO quartet.
-                for ls = 1:Ll
-                    L = loff + ls
-                    bl = Lijk*(ls-1)
-                    for ks = 1:Lk
-                        K = koff + ks
-                        L < K ? break : nothing
+            # Compute ERI
+            ERI_2e4c!(buf, BS, i, j, k ,l)
 
-                        # L ≥ K
-                        KL = (L * (L + 1)) >> 1 + K                            
-                        bkl = Lij*(ks-1) + bl
-                        for js = 1:Lj
-                            J = joff + js
-                            bjkl = Li*(js-1) + bkl
-                            for is = 1:Li
-                                I = ioff + is
-                                J < I ? break : nothing
+            ### This block aims to retrieve unique elements within buf and map them to AO indexes
+            # is, js, ks, ls are indexes within the shell e.g. for a p shell is = (1, 2, 3)
+            # bl, bkl, bjkl are used to map the (i,j,k,l) index into a one-dimensional index for buf
+            # That is, get the correct integrals for the AO quartet.
+            for ls = 1:Ll
+                L = loff + ls
+                bl = Lijk*(ls-1)
+                for ks = 1:Lk
+                    K = koff + ks
+                    L < K && break
 
-                                IJ = (J * (J + 1)) >> 1 + I
+                    # L ≥ K
+                    KL = (L * (L + 1)) >> 1 + K
+                    bkl = Lij*(ks-1) + bl
+                    for js = 1:Lj
+                        J = joff + js
+                        bjkl = Li*(js-1) + bkl
+                        for is = 1:Li
+                            I = ioff + is
+                            J < I && break
 
-                                #KL < IJ ? continue : nothing # This restriction does not work... idk why 
+                            IJ = (J * (J + 1)) >> 1 + I
 
-                                idx = index2(IJ,KL) + 1
-                                out[idx] = buf[is + bjkl]
-                                indexes[idx] = (I, J, K, L)
-                            end
+                            #KL < IJ ? continue : nothing # This restriction does not work... idk why
+
+                            idx = index2(IJ,KL) + 1
+                            out[idx] = buf[is + bjkl]
+                            indexes[idx] = (I, J, K, L)
                         end
                     end
                 end
             end
-        end #inbounds
-        end #spawn
-    end #sync
+        end
+    end
     mask = abs.(out) .> cutoff
     return indexes[mask], out[mask]
 end
@@ -160,13 +143,12 @@ function ERI_2e4c!(out, BS::BasisSet)
     end
 
     # Initialize array for results
-    bufs = [zeros(Cdouble, Nmax^4) for _ = 1:Threads.nthreads()]
-    Threads.@threads :static for (i,j,k,l) in unique_idx
+    allocate(body) = body(zeros(Cdouble, Nmax^4))
+    workerpool(allocate, unique_idx; chunksize=10) do (i,j,k,l), buf
         # Shift indexes (C starts with 0, Julia 1)
         id, jd, kd, ld = i+1, j+1, k+1, l+1
         Ni, Nj, Nk, Nl = Nvals[id], Nvals[jd], Nvals[kd], Nvals[ld]
 
-        buf = bufs[Threads.threadid()]
         # Compute ERI
         ERI_2e4c!(buf, BS, id, jd, kd, ld)
 

--- a/src/Integrals/TwoElectronFourCenter.jl
+++ b/src/Integrals/TwoElectronFourCenter.jl
@@ -116,7 +116,7 @@ function ERI_2e4c(BS::BasisSet, i, j, k, l)
 end
 
 function ERI_2e4c!(out, BS::BasisSet{LCint}, i, j, k, l)
-    cint2e_sph!(out, [i,j,k,l], BS.lib)
+    cint2e_sph!(out, @SVector([i,j,k,l]), BS.lib)
 end
 
 function ERI_2e4c!(out, BS::BasisSet, i, j, k, l)

--- a/src/Integrals/TwoElectronThreeCenter.jl
+++ b/src/Integrals/TwoElectronThreeCenter.jl
@@ -25,42 +25,38 @@ function ERI_2e3c!(out, BS1::BasisSet, BS2::BasisSet)
     ao_offset1 = [sum(Nvals1[1:(i-1)]) for i = 1:BS1.nshells]
     ao_offset2 = [sum(Nvals2[1:(i-1)]) for i = 1:BS2.nshells]
 
-    buf_arrays = [zeros(Cdouble, Nmax1^2*Nmax2) for _ = 1:Threads.nthreads()]
+    allocate(body) = body(zeros(Cdouble, Nmax1^2*Nmax2))
+    workerpool(allocate, 1:BS2.nshells; chunksize=1) do k, buf
+        @inbounds begin
+            Nk = Nvals2[k]
+            koff = ao_offset2[k]
+            for i in 1:BS1.nshells
+                Ni = Nvals1[i]
+                ioff = ao_offset1[i]
+                for j in i:BS1.nshells
+                    Nj = Nvals1[j]
+                    joff = ao_offset1[j]
 
-    @sync for k in 1:BS2.nshells
-        Threads.@spawn begin
-            @inbounds begin
-                buf = buf_arrays[Threads.threadid()]
-                Nk = Nvals2[k]
-                koff = ao_offset2[k]
-                for i in 1:BS1.nshells
-                    Ni = Nvals1[i]
-                    ioff = ao_offset1[i]
-                    for j in i:BS1.nshells
-                        Nj = Nvals1[j]
-                        joff = ao_offset1[j]
+                    # Call libcint
+                    ERI_2e3c!(buf, BS1, BS2, i, j, k)
 
-                        # Call libcint
-                        ERI_2e3c!(buf, BS1, BS2, i, j, k) 
-
-                        # Loop through shell block and save unique elements
-                        for ks = 1:Nk
-                            K = koff + ks
-                            for js = 1:Nj
-                                J = joff + js
-                                for is = 1:Ni
-                                    I = ioff + is
-                                    J < I ? break : nothing
-                                    out[I,J,K] = buf[is + Ni*(js-1) + Ni*Nj*(ks-1)]
-                                    out[J,I,K] = out[I,J,K]
-                                end
+                    # Loop through shell block and save unique elements
+                    for ks = 1:Nk
+                        K = koff + ks
+                        for js = 1:Nj
+                            J = joff + js
+                            for is = 1:Ni
+                                I = ioff + is
+                                J < I ? break : nothing
+                                out[I,J,K] = buf[is + Ni*(js-1) + Ni*Nj*(ks-1)]
+                                out[J,I,K] = out[I,J,K]
                             end
                         end
                     end
                 end
-            end #inbounds
-        end #spwan
-    end #sync
+            end
+        end #inbounds
+    end
     return out
 end
 
@@ -81,41 +77,38 @@ function ERI_2e3c!(out, BS1::BasisSet{LCint}, BS2::BasisSet{LCint})
     ao_offset1 = [sum(Nvals1[1:(i-1)]) for i = 1:BS1.nshells]
     ao_offset2 = [sum(Nvals2[1:(i-1)]) for i = 1:BS2.nshells]
 
-    buf_arrays = [zeros(Cdouble, Nmax1^2*Nmax2) for _ = 1:Threads.nthreads()]
 
-    @sync for k in 1:BS2.nshells
-        Threads.@spawn begin
-            @inbounds begin
-                buf = buf_arrays[Threads.threadid()]
-                Nk = Nvals2[k]
-                koff = ao_offset2[k]
-                for i in 1:BS1.nshells
-                    Ni = Nvals1[i]
-                    ioff = ao_offset1[i]
-                    for j in i:BS1.nshells
-                        Nj = Nvals1[j]
-                        joff = ao_offset1[j]
+    allocate(body) = body(zeros(Cdouble, Nmax1^2*Nmax2))
+    workerpool(allocate, 1:BS2.nshells; chunksize = 1) do k, buf
+        @inbounds begin
+            Nk = Nvals2[k]
+            koff = ao_offset2[k]
+            for i in 1:BS1.nshells
+                Ni = Nvals1[i]
+                ioff = ao_offset1[i]
+                for j in i:BS1.nshells
+                    Nj = Nvals1[j]
+                    joff = ao_offset1[j]
 
-                        # Call libcint
-                        ERI_2e3c!(buf, Bmerged, i, j, k+BS1.nshells) 
+                    # Call libcint
+                    ERI_2e3c!(buf, Bmerged, i, j, k+BS1.nshells)
 
-                        # Loop through shell block and save unique elements
-                        for ks = 1:Nk
-                            K = koff + ks
-                            for js = 1:Nj
-                                J = joff + js
-                                for is = 1:Ni
-                                    I = ioff + is
-                                    J < I ? break : nothing
-                                    out[I,J,K] = buf[is + Ni*(js-1) + Ni*Nj*(ks-1)]
-                                    out[J,I,K] = out[I,J,K]
-                                end
+                    # Loop through shell block and save unique elements
+                    for ks = 1:Nk
+                        K = koff + ks
+                        for js = 1:Nj
+                            J = joff + js
+                            for is = 1:Ni
+                                I = ioff + is
+                                J < I ? break : nothing
+                                out[I,J,K] = buf[is + Ni*(js-1) + Ni*Nj*(ks-1)]
+                                out[J,I,K] = out[I,J,K]
                             end
                         end
                     end
                 end
-            end #inbounds
-        end #spwan
-    end #sync
+            end
+        end #inbounds
+    end
     return out
 end

--- a/src/Libcint.jl
+++ b/src/Libcint.jl
@@ -30,7 +30,7 @@ function cint1e_ovlp_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                 )::Cvoid
 end
-function cint1e_ovlp_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint1e_ovlp_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_ovlp_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -45,7 +45,7 @@ function cint1e_kin_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                 )::Cvoid
 end
-function cint1e_kin_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint1e_kin_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_kin_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -60,7 +60,7 @@ function cint1e_nuc_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                 )::Cvoid
 end
-function cint1e_nuc_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint1e_nuc_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_nuc_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -77,7 +77,7 @@ function cint2e_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     opt :: Ptr{UInt8},
                                 )::Cvoid
 end
-function cint2e_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint2e_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint2e_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -94,7 +94,7 @@ function cint2c2e_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     opt :: Ptr{UInt8},
                                 )::Cvoid
 end
-function cint2c2e_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint2c2e_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint2c2e_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -111,7 +111,7 @@ function cint3c2e_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     opt :: Ptr{UInt8},
                                 )::Cvoid
 end
-function cint3c2e_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint3c2e_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint3c2e_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -126,7 +126,7 @@ function cint1e_ipovlp_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                    )::Cvoid
 end
-function cint1e_ipovlp_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint1e_ipovlp_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_ipovlp_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -141,7 +141,7 @@ function cint1e_ipipovlp_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                    )::Cvoid
 end
-function cint1e_ipipovlp_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint)
+function cint1e_ipipovlp_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_ipipovlp_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -157,7 +157,7 @@ function cint1e_ipkin_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                    )::Cvoid
 end
-function cint1e_ipkin_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint1e_ipkin_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_ipkin_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -172,7 +172,7 @@ function cint1e_ipnuc_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                    )::Cvoid
 end
-function cint1e_ipnuc_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint1e_ipnuc_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_ipnuc_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -189,7 +189,7 @@ function cint2e_ip1_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     opt :: Ptr{UInt8},
                                    )::Cvoid
 end
-function cint2e_ip1_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint2e_ip1_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint2e_ip1_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -204,7 +204,7 @@ function cint1e_r_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                    )::Cvoid
 end
-function cint1e_r_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint) 
+function cint1e_r_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_r_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -219,7 +219,7 @@ function cint1e_rr_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                    )::Cvoid
 end
-function cint1e_rr_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint)
+function cint1e_rr_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_rr_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -234,7 +234,7 @@ function cint1e_rrr_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                    )::Cvoid
 end
-function cint1e_rrr_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint)
+function cint1e_rrr_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_rrr_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 
@@ -249,7 +249,7 @@ function cint1e_rrrr_sph!(buf, shls, atm, natm, bas, nbas, env)
                                     env  :: Ptr{Cdouble}
                                    )::Cvoid
 end
-function cint1e_rrrr_sph!(buf::Array{Cdouble}, shls::Array{<:Integer}, lib::LCint)
+function cint1e_rrrr_sph!(buf::Array{Cdouble}, shls::AbstractArray{<:Integer}, lib::LCint)
     cint1e_rrrr_sph!(buf, Cint.(shls.-1), lib.atm, lib.natm, lib.bas, lib.nbas, lib.env)
 end
 

--- a/src/Misc.jl
+++ b/src/Misc.jl
@@ -138,7 +138,7 @@ function show(io::IO, ::MIME"text/plain", X::T) where T<:Union{BasisFunction, Ba
 end
 
 # adapted from https://juliafolds.github.io/data-parallelism/tutorials/concurrency-patterns/
-function workerpool(work!, allocate, inputs; chunksize,ntasks = Threads.threadpoolsize())
+function workerpool(work!, allocate, inputs; chunksize,ntasks = Threads.nthreads())
     requests = Channel{Vector{eltype(inputs)}}(Inf)
     for chunk in Iterators.partition(inputs, chunksize)
         put!(requests, chunk)


### PR DESCRIPTION
In Julia 1.12, the default number of threads will be 1 worker and 1 interactive thread (`-t 1,1`). If the number of interactive threads is nonzero, the current code that relies on `Threads.threadid() <= Threads.nthreads()` will segfault.

The officially supported way to work around this is to use tasks instead. A pattern to do similar computation while sharing memory is a worker pool. This PR replaces previous reliance on `Threads.threadid()` by worker pools.

Based on some testing it seems this approach is not slower than what was done before. It also brings the advantage of being able to use GaussianBasis within code that is itself concurrent (currently impossible with `@threads :static`)

Additionally, I changed the bindings for Libcint to use SVectors instead of Vectors. This avoids a lot of small allocations, which may or may not be significant for performance.