### PR TITLE
Atomic orbital amplitudes

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,17 @@ julia> S
  1.0       0.646804
  0.646804  1.0
  ```
+
+### Evaluating orbital amplitudes
+
+The function `atomic_orbital_amplitude(basisset, i, r)` can be used to calculate the atomic orbital amplitude of the `i`th basis function at positions `r`. `r` can be either a 3-vector for a single position or a 3×… array for calculating many positions efficiently at once.
+
+```julia
+julia> bset = BasisSet("sto-3g", "H 0 0 0");
+julia> atomic_orbital_amplitude(bset, 1, [0.0,0.0,0.0])
+0.6282468778403579
+julia> atomic_orbital_amplitude(bset, 1, [0.1;0.2;0.3;;-0.1;0.3;-0.2])
+2-element Vector{Float64}:
+ 0.49840190793869554
+ 0.49840190793869554
+```

--- a/src/GaussianBasis.jl
+++ b/src/GaussianBasis.jl
@@ -5,7 +5,7 @@ using Format
 using StaticArrays
 import Molecules: Atom, symbol, parse_file, parse_string
 
-export BasisFunction, BasisSet, SphericalShell, CartesianShell, get_shell
+export BasisFunction, BasisSet, SphericalShell, CartesianShell, get_shell, atomic_orbital_amplitude
 
 abstract type BasisFunction end
 

--- a/src/Misc.jl
+++ b/src/Misc.jl
@@ -155,3 +155,125 @@ function workerpool(work!, allocate, inputs; chunksize,ntasks = Threads.nthreads
         end
     end
 end
+
+
+function legendre_polynomial(m::Integer,l::Integer,x)
+    fmm = (-1)^m * prod((2m-1):-2:1)
+    Pmm = fmm * (1 - x^2)^(m/2)
+    if l == m
+        return Pmm
+    end
+    Pmm1 = x * (2m+1) * Pmm
+
+    if l < m || m < 0
+        throw(DomainError("Associated Legendre polynomials are only defined for 0 ≤ m ≤ l, got m = $m, l = $l"))
+    end
+
+    Pmm2 = zero(Pmm)
+    for i = m+2:l
+        Pmm2 = ((2i-1)*x*Pmm1 - (i-1+m) * Pmm)/(i-m)
+        Pmm = Pmm1
+        Pmm1 = Pmm2
+    end
+    return Pmm1
+end
+
+
+function atomic_orbital_angular_part(shell::SphericalShell, n::Integer, d, d²)
+    l = shell.l
+    m = n - l - 1
+
+    # for p shell, ordering is px, py, pz <=> m = 1,-1,0
+    if l == 1
+        m = (1, -1, 0)[n]
+    end
+
+    sqrtd² = sqrt.(d²)
+    cosθ = map(selectdim(d, 1, 3), sqrtd²) do z, sqrtd²
+        ifelse(iszero(z), zero(z), z / sqrtd²)
+    end
+    Nlm = (-1)^m * sqrt((2l + 1) / (4π * prod(l - abs(m) + 1:l + abs(m))))
+    Plm = legendre_polynomial.(abs(m), l, cosθ)
+
+    v = @. sqrtd²^l * Nlm * Plm
+    if m != 0
+        φ = [atan(x[2],x[1]) for x in eachslice(d, dims=tuple(2:ndims(d)...))]
+        if m > 0
+            @. v *= sqrt(2) * cos(m * φ)
+        else
+            @. v *= sqrt(2) * sin(-m * φ)
+        end
+    end
+
+    return v
+end
+
+
+function atomic_orbital_amplitude(shell::BasisFunction, n::Integer, r::AbstractArray)
+    T = promote_type(eltype(shell.coef), eltype(shell.exp), eltype(r), eltype(shell.atom.xyz))
+
+    if size(r,1) != 3
+        throw(DimensionMismatch("First dimension of r must be 3, got $(size(r,1))"))
+    end
+
+    v = zeros(T, size(r)[2:end])
+
+    d = r .- shell.atom.xyz ./ Molecules.bohr_to_angstrom
+
+    d² = dropdims(sum(x->x^2, d; dims=1); dims=1)
+
+    for (c, e) in zip(shell.coef, shell.exp)
+        @. v += c * exp(-e * d²)
+    end
+
+    v .*= atomic_orbital_angular_part(shell, n, d, d²)
+    return v
+end
+
+function find_shell_m(B::BasisSet, idx::Integer)
+    if idx <= 0
+        throw(BoundsError(B, idx))
+    end
+
+    n = idx
+    for shell in B.basis
+        if n - (2shell.l +1) <= 0
+            m = n - shell.l - 1
+
+            # for p shell, ordering is px, py, pz <=> m = 1,-1,0
+            if shell.l == 1
+                m = (1, -1, 0)[n]
+            end
+
+            return shell, n
+        end
+        n -= 2shell.l + 1
+    end
+
+    throw(BoundsError(B, idx))
+end
+
+"""
+    atomic_orbital_value(B::BasisSet, i::Integer, r::AbstractVector) -> Real
+    atomic_orbital_value(B::BasisSet, i::Integer, r::AbstractArray) -> AbstractArray
+
+Returns the amplitude of the `i`th basis function at a set of real space positions. `r` can be either a 3-vector containing a single position or a 3 × … array of positions for evaluating many points at once more efficiently.
+
+# Examples
+
+```julia-repl
+julia> bset = BasisSet("sto-3g", "H 0 0 0");
+julia> atomic_orbital_amplitude(bset, 1, [0.0,0.0,0.0])
+0.6282468778403579
+julia> atomic_orbital_amplitude(bset, 1, [0.1;0.2;0.3;;-0.1;0.3;-0.2])
+2-element Vector{Float64}:
+ 0.49840190793869554
+ 0.49840190793869554
+```
+"""
+function atomic_orbital_amplitude(B::BasisSet, idx::Integer, r::AbstractArray)
+    return atomic_orbital_amplitude(find_shell_m(B, idx)..., r)
+end
+function atomic_orbital_amplitude(B::BasisSet, idx::Integer, r::AbstractVector)
+    return atomic_orbital_amplitude(B, idx, reshape(r,:,1))[1]
+end

--- a/src/Misc.jl
+++ b/src/Misc.jl
@@ -4,7 +4,7 @@ function string_repr(B::SphericalShell)
 
     # Unicode for superscript is a bit messier, so gotta use control flow
     l_sup = B.l == 1 ? Char(0x00B9) :
-            B.l in [2,3] ? Char(0x00B1 + B.l) :
+            B.l in [2,3] ? Char(0x00B0 + B.l) :
             Char(0x2070 + B.l)
 
     nbas = 2*B.l + 1

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -19,9 +19,70 @@ shells = [
 bset = BasisSet("Test", atoms, shells)
 
 @testset "Misc" begin
-    @test GaussianBasis.string_repr(shells[1]) == "S shell with 1 basis built from 2 primitive gaussians\n\nχ₀₀  =    0.7071067812⋅Y₀₀⋅exp(-5.0⋅r²)\n     +    0.7071067812⋅Y₀₀⋅exp(-1.2⋅r²)" 
-    @test occursin(r"Test Basis\s+?Set\nType:\s+?Spherical", GaussianBasis.string_repr(bset))
-    @test occursin(r"Number of shells:\s?+6\nNumber of basis:\s+?8", GaussianBasis.string_repr(bset))
-    @test occursin(r"C: 1s 1p\s+?\nH: 1s\s+?\nH: 1s\s+?\nH: 1s\s+?\nH: 1s\s*", GaussianBasis.string_repr(bset))
+    @testset "string_repr" begin
+        @test GaussianBasis.string_repr(shells[1]) == "S shell with 1 basis built from 2 primitive gaussians\n\nχ₀₀  =    0.7071067812⋅Y₀₀⋅exp(-5.0⋅r²)\n     +    0.7071067812⋅Y₀₀⋅exp(-1.2⋅r²)"
+        @test occursin(r"Test Basis\s+?Set\nType:\s+?Spherical", GaussianBasis.string_repr(bset))
+        @test occursin(r"Number of shells:\s?+6\nNumber of basis:\s+?8", GaussianBasis.string_repr(bset))
+        @test occursin(r"C: 1s 1p\s+?\nH: 1s\s+?\nH: 1s\s+?\nH: 1s\s+?\nH: 1s\s*", GaussianBasis.string_repr(bset))
+    end
+
     @test bset[1] == bset.basis[1]
+
+    @testset "legendre_polynomial" begin
+        examples = [
+            (0, 0, -0.42, +1.000000000000)
+            (1, 0, +0.33, +0.330000000000)
+            (1, 1, +0.33, -0.943980932011)
+            (2, 0, -0.80, +0.460000000000)
+            (2, 1, -0.80, +1.440000000000)
+            (2, 2, -0.80, +1.080000000000)
+            (3, 0, +0.70, -0.192500000000)
+            (3, 1, +0.70, -1.553260683208)
+            (3, 2, +0.70, +5.355000000000)
+            (3, 3, +0.70, -5.463192747835)
+            (4, 0, -0.30, +0.072937500000)
+            (4, 1, -0.30, -1.695626930519)
+            (4, 2, -0.30, -2.525250000000)
+            (4, 3, -0.30, +27.344667208617)
+            (4, 4, -0.30, +86.950500000000)
+            (5, 0, +0.50, +0.089843750000)
+            (5, 1, +0.50, +1.928259688114)
+            (5, 2, +0.50, -4.921875000000)
+            (5, 3, +0.50, -42.624687842515)
+            (5, 4, +0.50, +265.781250000000)
+            (5, 5, +0.50, -460.346628699166)
+        ]
+
+        for (l,m,x,expected) in examples
+            @test GaussianBasis.legendre_polynomial(m,l,x) ≈ expected
+        end
+    end
+
+    @testset "atomic_orbital_amplitude" begin
+        dx = 0.07
+
+        bset = BasisSet("cc-pvdz", "C 0.1 -0.5 -0.13\nC -0.1 0.05 0.13")
+
+        # test s, p, and d shells
+        idxs = [1, 4, 5, 25, 28]
+        coef = sin.(idxs)
+
+        b = range(-3, 3; step=dx)
+
+        xs = [(x, y, z)[i] for i = 1:3, x in b, y in b, z in b]
+
+        r = 0.0
+        refidx = 1
+        ref = atomic_orbital_amplitude(bset, refidx, xs)
+        for (i, c) in zip(idxs, coef)
+            r += c * sum(ref .* atomic_orbital_amplitude(bset, i, xs))
+        end
+        r *= dx^3
+
+        ovlp = overlap(bset)
+        @test isapprox(r, sum(c*ovlp[refidx, i] for (i,c) in zip(idxs, coef)), rtol=0.05)
+
+        @test atomic_orbital_amplitude(bset, 1, [0,0,1]) isa Real
+        @test_throws BoundsError atomic_orbital_amplitude(bset, 100, [0,0,1])
+    end
 end


### PR DESCRIPTION
This PR (sorry for the flood of PRs)

- fixes a bug in the string representation that would show the wrong power of `r` for spherical `d` and `f` shells.
- introduces a new function `atomic_orbital_amplitude(bset, idx, r)` that allows evaluating the atomic orbital wavefunctions at arbitrary positions for generating volumetric data for visualizations.

The functionality is tested by integrating the values naively and comparing if they match the overlap integrals.
Comments on the API are welcome. I am also not sure if I missed existing convenience functions e.g. for finding the right shell for a given index.

Currently only spherical shells are implemented. I also encountered #24 for Cartesian shells. The naive integration of the amplitudes yields properly normalized overlaps, but the libcint overlaps are very different and sometimes even zero on the diagonal. Could it be that calling the `_cart` libcint functions is required to get the proper Cartesian integrals?
