### PR TITLE
Ensure `BasisSet` is type stable

### DIFF
--- a/src/BasisSet.jl
+++ b/src/BasisSet.jl
@@ -110,13 +110,13 @@ function BasisSet(name::String, str_atoms::String; spherical=true::Bool, lib=:li
     return build_basis_from_file(Val(spherical), name, atoms, lib)
 end
 
-@inline build_basis_from_file(::Val{true}, name::String, atoms::Vector{A}, lib::Symbol) where {A<:Atom} =
+build_basis_from_file(::Val{true}, name::String, atoms::Vector{A}, lib::Symbol) where {A<:Atom} =
     construct_basis_from_library(SphericalShell, name, atoms, Val(lib))
 
-@inline build_basis_from_file(::Val{false}, name::String, atoms::Vector{A}, lib::Symbol) where {A<:Atom} =
+build_basis_from_file(::Val{false}, name::String, atoms::Vector{A}, lib::Symbol) where {A<:Atom} =
     construct_basis_from_library(CartesianShell, name, atoms, Val(lib))
 
-@inline function construct_basis_from_library(::Type{B}, name::String, atoms::Vector{A}, ::Val{:libcint}) where {B<:BasisFunction,A<:Atom}
+function construct_basis_from_library(::Type{B}, name::String, atoms::Vector{A}, ::Val{:libcint}) where {B<:BasisFunction,A<:Atom}
     basis = B[]
     for atom in atoms
         append!(basis, read_basisset(B, name, atom))
@@ -124,7 +124,7 @@ end
     BasisSet(name, atoms, basis, LCint(atoms, basis))
 end
 
-@inline function construct_basis_from_library(::Type{B}, name::String, atoms::Vector{A}, ::Val{:acsint}) where {B<:BasisFunction,A<:Atom}
+function construct_basis_from_library(::Type{B}, name::String, atoms::Vector{A}, ::Val{:acsint}) where {B<:BasisFunction,A<:Atom}
     basis = B[]
     for atom in atoms
         append!(basis, read_basisset(B, name, atom))
@@ -162,7 +162,7 @@ end
 BasisSet(name::String, atoms::Vector{A}, basis::Vector{B}) where {A<:Atom,B<:BasisFunction} =
     BasisSet(name, atoms, basis, LCint(atoms, basis))
 
-@inline BasisSet(name::String, atoms::Vector{A}; spherical::Bool=true, lib::Symbol=:libcint) where {A<:Atom} =
+BasisSet(name::String, atoms::Vector{A}; spherical::Bool=true, lib::Symbol=:libcint) where {A<:Atom} =
     build_basis_from_file(Val(spherical), name, atoms, lib)
 
 function normalize_shell!(::Type{SphericalShell}, coef, exp, n)

--- a/src/GaussianBasis.jl
+++ b/src/GaussianBasis.jl
@@ -5,7 +5,7 @@ using Format
 using StaticArrays
 import Molecules: Atom, symbol, parse_file, parse_string
 
-export BasisFunction, BasisSet, SphericalShell, CartesianShell, get_shell
+export BasisFunction, BasisSet, SphericalShell, CartesianShell, get_shell, ACSint, LCint
 
 abstract type BasisFunction end
 
@@ -38,10 +38,10 @@ P shell with 3 basis built from 2 primitive gaussians
      +    0.7071067812⋅Y₁₁⋅r¹⋅exp(-1.2⋅r²)
 ```
 """
-struct SphericalShell{A<:Atom, R} <: BasisFunction
+struct SphericalShell{A<:Atom} <: BasisFunction
     l::Int
-    coef::Vector{R}
-    exp::Vector{R}
+    coef::Vector{Float64}
+    exp::Vector{Float64}
     atom::A
 end
 
@@ -77,10 +77,10 @@ D shell with 6 basis built from 1 primitive gaussians
 χ(z²) =    0.7071067812⋅z²⋅exp(-5.0⋅r²)
 ```
 """
-struct CartesianShell{A<:Atom, R} <: BasisFunction
+struct CartesianShell{A<:Atom} <: BasisFunction
     l::Int
-    coef::Vector{R}
-    exp::Vector{R}
+    coef::Vector{Float64}
+    exp::Vector{Float64}
     atom::A
 end
 

--- a/src/Libs.jl
+++ b/src/Libs.jl
@@ -11,7 +11,7 @@ struct LCint <: IntLib
     env::Vector{Cdouble}
 end
 
-function LCint(atoms::Vector{<:Atom}, basis::Vector{<:BasisFunction})
+function LCint(atoms::Vector{At}, basis::Vector{Bs}) where {At<:Atom,Bs<:BasisFunction}
     ATM_SLOTS = 6
     BAS_SLOTS = 8
 


### PR DESCRIPTION
I should have made this change minimal but it takes more effort than I expected.
After this PR
```julia
julia> function run()
       bset = BasisSet("cc-pvtz", "N 0 0 1\nN 0 0 -1", spherical=false, lib=:acsint)
       end
julia> @code_warntype run()
MethodInstance for run()
  from run() @ Main REPL[6]:1
Arguments
  #self#::Core.Const(Main.run)
Locals
  bset::BasisSet{ACSint, Molecules.Atom, CartesianShell}
Body::BasisSet{ACSint, Molecules.Atom, CartesianShell}
1 ─ %1 = (:spherical, :lib)::Core.Const((:spherical, :lib))
│   %2 = Core.apply_type(Core.NamedTuple, %1)::Core.Const(NamedTuple{(:spherical, :lib)})
│   %3 = Core.tuple(false, :acsint)::Core.Const((false, :acsint))
│   %4 = (%2)(%3)::Core.Const((spherical = false, lib = :acsint))
│   %5 = Main.BasisSet::Core.Const(BasisSet)
│   %6 = Core.kwcall(%4, %5, "cc-pvtz", "N 0 0 1\nN 0 0 -1")::BasisSet{ACSint, Molecules.Atom, CartesianShell}
│        (bset = %6)
└──      return %6
```
I mainly delete the if else options for `spherical` boolean. I used AI but am confident that they are right.

Another change requiring your opinon, the Shell{A,R} is specified by R. I would think that restricting to Float64 may simplify the code while improving type stability.

I didn't see any speed up or regression after this PR.

Fix #29 